### PR TITLE
Add bazel build config for hs-msgpack-types.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,20 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
+
+haskell_library(
+    name = "hs-msgpack-types",
+    srcs = glob(["src/**/*.*hs"]),
+    prebuilt_dependencies = [
+        "base",
+        "bytestring",
+        "containers",
+        "deepseq",
+    ],
+    src_strip_prefix = "src",
+    deps = [
+        "@haskell_QuickCheck//:QuickCheck",
+        "@haskell_hashable//:hashable",
+        "@haskell_text//:text",
+        "@haskell_unordered_containers//:unordered-containers",
+        "@haskell_vector//:vector",
+    ],
+)


### PR DESCRIPTION
We can't build vector yet, so it's disabled in bazel, enabled in cabal.

See https://github.com/tweag/rules_haskell/issues/95.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/4)
<!-- Reviewable:end -->
