### PR TITLE
Make hs-msgpack-types visible to other bazel packages.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,7 @@ haskell_library(
         "deepseq",
     ],
     src_strip_prefix = "src",
+    visibility = ["//visibility:public"],
     deps = [
         "@haskell_QuickCheck//:QuickCheck",
         "@haskell_hashable//:hashable",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/5)
<!-- Reviewable:end -->
