### PR TITLE
Add GHC warning flags to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,11 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 haskell_library(
     name = "hs-msgpack-types",
     srcs = glob(["src/**/*.*hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = [
         "base",
         "bytestring",

--- a/src/Data/MessagePack/Types/Generic.hs
+++ b/src/Data/MessagePack/Types/Generic.hs
@@ -105,7 +105,7 @@ instance (GSumPack a, GSumPack b) => GSumPack (a :+: b) where
 
 
 instance GSumPack (C1 c U1) where
-  sumToObject code _ _ = toObject [code]
+  sumToObject code _ _ = toObject code
   sumFromObject _ _ = gFromObject
 
 

--- a/src/Data/MessagePack/Types/Object.hs
+++ b/src/Data/MessagePack/Types/Object.hs
@@ -7,13 +7,11 @@ module Data.MessagePack.Types.Object
   ( Object (..)
   ) where
 
-import           Control.Applicative       ((<$), (<$>), (<*>), (<|>))
+import           Control.Applicative       ((<$>), (<*>))
 import           Control.DeepSeq           (NFData (..))
 import qualified Data.ByteString           as S
-import qualified Data.ByteString.Lazy      as L
 import           Data.Int                  (Int64)
 import qualified Data.Text                 as T
-import qualified Data.Text.Lazy            as LT
 import           Data.Typeable             (Typeable)
 import           Data.Word                 (Word64, Word8)
 import           GHC.Generics              (Generic)


### PR DESCRIPTION
`-Werror` is fine here because we control the exact version of GHC we are
building with (currently 8.2.2), so there is no risk of getting different
warnings on different installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/7)
<!-- Reviewable:end -->
