### PR TITLE
Remove warning flags. These are now default.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,11 +10,7 @@ project(
 haskell_library(
     name = "hs-msgpack-types",
     srcs = glob(["src/**/*.*hs"]),
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-        "-Wno-unused-imports",
-    ],
+    compiler_flags = ["-Wno-unused-imports"],
     src_strip_prefix = "src",
     version = "0.0.2",
     visibility = ["//visibility:public"],
@@ -33,11 +29,7 @@ haskell_library(
 
 hspec_test(
     name = "test",
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-        "-Wno-unused-imports",
-    ],
+    compiler_flags = ["-Wno-unused-imports"],
     deps = [
         ":hs-msgpack-types",
         hazel_library("QuickCheck"),


### PR DESCRIPTION
toktok-stack sets default `-Wall -Werror.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/24)
<!-- Reviewable:end -->
