### PR TITLE
Use hs-tools scripts to simplify Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,35 +11,26 @@ env:
     - secure: "cTGxbP7X5pvMsvvrH960NOnLyL6H8zp/v7Vl0EI3s9pKEWfgcbNnkH8r5q/dO7MOpei6qqzwO+WCZGxGQRaISXydKyf8d3HriWlyAzg0PS1GMmpYdWkAoP3c/6K4BB09AXuiAnAwRxMYbrbJyGATA9zwqNB7UjaxMVMMb8Q9r+Ulm5o5lmOc37gqxRa7w+4MB6ayw5xSJC6+S2y56cocc4GKUeJaBU1xrsZevCHKtEgu8xoRgo/2gP0G8qCZDPTuHe7/iD+dXyNsNUtMKHZE3U5RSh2SvLtjRIjRkBgOICPYr/BgCX1303NOln85ZQeshf4KYulgsk4s5pqZ1dmuiz+gR97qKxulCLP5jTGRFHM3QfSutAcE40spXkc7Q62kLKBMcWFAQWo4DY9zW48ifEvhekYbqe5T5X6pzli06sWp7kqZThBQV3AmiZeHldiPiwnlXFPr4yzqnjZvoMgaSzMSwsNz94Kxr7Pr4hspwko/pe30sJktbdWP5fJnBoLKL7WNQlqtNfgFacyxnpjQXcIsrtopDbTmUKFb7URshfOuy7zQJybVSfFFgHXqWhUgn09BBxGcR29l8mf/NEO7RWb776w+KkZhw6/lMt68lZXoJsnDOFN3EsVWt5eok2RuJ4xxvnst2ogP2JMVL1IpBQfr8uiE9TBhtNgJCicCQfA="
 
 cache:
+  timeout: 600
   directories:
+    - $HOME/.local
     - $HOME/.stack
 
-before_install:
-  - export PATH=$HOME/.local/bin:$PATH
-  - travis_retry curl -L https://github.com/TokTok/hs-tools/releases/download/v0.6/hs-tools-v0.6.tar.gz | tar xz -C $HOME
-
 script:
-  - hlint .
-  - stylish-haskell-lhs -i .
-  - git diff --exit-code
-  - stack --no-terminal test --coverage
-  - shc msgpack-types testsuite
-  - stack sdist --tar-dir .
+  - bash <(travis_retry curl -s https://raw.githubusercontent.com/TokTok/hs-tools/master/bin/travis-haskell) script
+  - eval $(travis-haskell env)
 
 deploy:
   provider: releases
   token:
     secure: "GETDyyKHg5qRIICJGLMEGjxqajLDkFHg176fNgxc+M2+6X45a9afutBR3yqMTbDxQG1N11aNJII10JX3YxPAl9UKCwiPOB/24VXpE5EA0BzT1T3XIkQK4y4+JAj6syf55xWxnh98r7KMwmchU7e/7zTUR7kJgndNc0CjYq19WowjOjX21SeGznb+MnefbYzBI+vjmNvZNlgi62BSJ4BidLXNnfnQbL+enebptWi8naFdF3A5+5rMMQ0c5pkJm3QBOK1JIphhYFWDH9QHpPO9kR8HVwV32ArMxxe5moznssHW9/SFnmaMXJn+t4N+57cCXEFrtBovIxf/Zxtk9kvRkzf0iC0Bpo5mHMCVZ4Yd0IliUg+VszUa0LO/DOJutn9U3HcG1JcD5B3Mb8pdGwcb7/hRKI6gvwmb/YyJa2AIeiI3eXHCouWXtBM9Y0b/eSVmlJC+EpVMTaDtro7raX+UWwme470EiQ21cTXmwGOIrD4+/ooYOYKu7PaO0Ti6xsHuW0cAl0KF5O2y3wiCkU1i0aBt3xo96Brthar3MsGCplCX8JK0kNQr6iq1WkeDAVkJkek95ylG/udbbrfa6lStzoa7mzdq1OktafmCVoe0P4WCWf6VBQvTSRZVIHhjp8wIbYSP4MNIxLR+eguyjX0+6Z1UFBY68vIRRvRqX/6dKpg="
-  file: msgpack-types-0.0.4.tar.gz
+  file: $PACKAGE-$VERSION.tar.gz
   skip_cleanup: true
   on:
     repo: TokTok/hs-msgpack-types
     tags: true
 
-after_deploy:
-  - mkdir -p "$HOME/.stack/upload"
-  - echo "{\"username\":\"$HACKAGE_USERNAME\",\"password\":\"$HACKAGE_PASSWORD\"}" > $HOME/.stack/upload/credentials.json
-  - stack --no-terminal upload .
+after_deploy: travis-haskell deploy
 
 # Only build pull requests and releases, don't build master on pushes,
 # except through api or cron.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,12 +3,9 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-VERSION = "0.0.4"
-
 project(
     license = "hs-msgpack",
     standard_travis = True,
-    version = VERSION,
 )
 
 haskell_library(
@@ -16,7 +13,7 @@ haskell_library(
     srcs = glob(["src/**/*.*hs"]),
     compiler_flags = ["-Wno-unused-imports"],
     src_strip_prefix = "src",
-    version = VERSION,
+    version = "0.0.4",
     visibility = ["//visibility:public"],
     deps = [
         hazel_library("QuickCheck"),


### PR DESCRIPTION
Also, we no longer need to write the version number to .travis.yml, because
we can infer it from the travis tag. We couldn't do that before, because it's
a bit of code we don't want to repeat in every repo. Now that it's common, we
can write it and download it into each repo's build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/30)
<!-- Reviewable:end -->
