### PR TITLE
chore: Add github workflow for cabal build and hackage upload.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.11
+    image: toxchat/toktok-stack:0.0.15
     cpu: 2
     memory: 4G
   configure_script:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,6 +12,7 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - cirrus-ci
-          - Codacy Static Code Analysis
-          - code-review/reviewable
+          - "Cabal Build / build (pull_request)"
+          - "cirrus-ci"
+          - "Codacy Static Code Analysis"
+          - "code-review/reviewable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Cabal Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-haskell@v1
+        with:
+          ghc-version: "8.10.3"
+          cabal-version: "3.2"
+
+      - name: Cache
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-cabal
+        with:
+          path: ~/.cabal
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          cabal update
+          cabal build --only-dependencies --enable-tests --enable-benchmarks --enable-doc all
+      - name: Build
+        run: cabal build --enable-tests --enable-benchmarks --enable-doc all
+      - name: Run tests
+        run: cabal test --enable-doc all
+      - name: Build haddock documentation
+        run: cabal haddock --haddock-for-hackage --enable-doc
+
+      - name: Publish candidate to Hackage
+        env:
+          API_TOKEN_HACKAGE: ${{ secrets.API_TOKEN_HACKAGE }}
+        run: |
+          PACKAGE=$(grep '^name:' *.cabal | awk '{print $2}')
+          VERSION=$(grep '^version:' *.cabal | awk '{print $2}')
+          cabal sdist
+          curl --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
+            -F "package=@dist-newstyle/sdist/$PACKAGE-$VERSION.tar.gz" \
+            "https://hackage.haskell.org/packages/candidates"
+          curl --header "Authorization: X-ApiKey $API_TOKEN_HACKAGE" \
+            -X PUT \
+            -H "Content-Type: application/x-tar" \
+            -H "Content-Encoding: gzip" \
+            --data-binary "@dist-newstyle/$PACKAGE-$VERSION-docs.tar.gz" \
+            "https://hackage.haskell.org/package/$PACKAGE-$VERSION/candidate/docs"


### PR DESCRIPTION
This uploads a package candidate on each master build. We will still need a
production build on each tag, later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/41)
<!-- Reviewable:end -->
