### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.15
+    image: toxchat/toktok-stack:0.0.16
     cpu: 2
-    memory: 4G
+    memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-msgpack-types
   test_all_script:

--- a/src/Data/MessagePack/Types/Assoc.hs
+++ b/src/Data/MessagePack/Types/Assoc.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE Trustworthy                #-}
 
 --------------------------------------------------------------------

--- a/src/Data/MessagePack/Types/Class.hs
+++ b/src/Data/MessagePack/Types/Class.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE StrictData          #-}
 {-# LANGUAGE Trustworthy         #-}
 
 --------------------------------------------------------------------

--- a/src/Data/MessagePack/Types/Generic.hs
+++ b/src/Data/MessagePack/Types/Generic.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE Safe                #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData          #-}
 {-# LANGUAGE TypeOperators       #-}
 module Data.MessagePack.Types.Generic () where
 

--- a/src/Data/MessagePack/Types/Instances.hs
+++ b/src/Data/MessagePack/Types/Instances.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE StrictData #-}
 module Data.MessagePack.Types.Instances () where
 
 import           Data.Void                      (Void)

--- a/src/Data/MessagePack/Types/Object.hs
+++ b/src/Data/MessagePack/Types/Object.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE Safe               #-}
+{-# LANGUAGE StrictData         #-}
 module Data.MessagePack.Types.Object
     ( Object (..)
     ) where
@@ -22,25 +23,25 @@ import qualified Test.QuickCheck.Gen       as Gen
 data Object
     = ObjectNil
       -- ^ represents nil
-    | ObjectBool                  !Bool
+    | ObjectBool                  Bool
       -- ^ represents true or false
-    | ObjectInt    {-# UNPACK #-} !Int64
+    | ObjectInt    {-# UNPACK #-} Int64
       -- ^ represents a negative integer
-    | ObjectWord   {-# UNPACK #-} !Word64
+    | ObjectWord   {-# UNPACK #-} Word64
       -- ^ represents a positive integer
-    | ObjectFloat  {-# UNPACK #-} !Float
+    | ObjectFloat  {-# UNPACK #-} Float
       -- ^ represents a floating point number
-    | ObjectDouble {-# UNPACK #-} !Double
+    | ObjectDouble {-# UNPACK #-} Double
       -- ^ represents a floating point number
-    | ObjectStr                   !T.Text
+    | ObjectStr                   T.Text
       -- ^ extending Raw type represents a UTF-8 string
-    | ObjectBin                   !S.ByteString
+    | ObjectBin                   S.ByteString
       -- ^ extending Raw type represents a byte array
-    | ObjectArray                 ![Object]
+    | ObjectArray                 [Object]
       -- ^ represents a sequence of objects
-    | ObjectMap                   ![(Object, Object)]
+    | ObjectMap                   [(Object, Object)]
       -- ^ represents key-value pairs of objects
-    | ObjectExt    {-# UNPACK #-} !Word8 !S.ByteString
+    | ObjectExt    {-# UNPACK #-} Word8 S.ByteString
       -- ^ represents a tuple of an integer and a byte array where
       -- the integer represents type information and the byte array represents data.
     deriving (Read, Show, Eq, Ord, Typeable, Generic)

--- a/test/Data/MessagePack/Types/ClassSpec.hs
+++ b/test/Data/MessagePack/Types/ClassSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData          #-}
 {-# LANGUAGE Trustworthy         #-}
 module Data.MessagePack.Types.ClassSpec where
 
@@ -99,12 +100,12 @@ spec :: Spec
 spec = do
     describe "GMessagePack" $ do
         it "is a reversible operation"
-            $ withMaxSuccess 100000
+            $ withMaxSuccess 10000
             $ property
             $ \(x :: MyType) -> fromObject (toObject x) `shouldBe` Just x
 
         it "handles arbitrary values"
-            $ withMaxSuccess 100000
+            $ withMaxSuccess 10000
             $ property
             $ \ob -> fromObject ob `shouldSatisfy` \case
                   Just EnumTyCon -> True


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.