### PR TITLE
feat: Add `==` and `/=` to DecodeError.

### DIFF
--- a/src/Data/MessagePack/Types/DecodeError.hs
+++ b/src/Data/MessagePack/Types/DecodeError.hs
@@ -14,7 +14,7 @@ import           Text.ParserCombinators.ReadPrec (ReadPrec)
 data DecodeError = DecodeError
     { errorMessages :: [String]
     }
-    deriving (Show)
+    deriving (Show, Eq)
 
 decodeError :: String -> DecodeError
 decodeError = DecodeError . (:[])

--- a/src/Data/MessagePack/Types/Generic.hs
+++ b/src/Data/MessagePack/Types/Generic.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE IncoherentInstances  #-}


### PR DESCRIPTION
Useful for tests where you want to compare error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-types/65)
<!-- Reviewable:end -->
